### PR TITLE
allow overriding CORS origin hosts

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,8 +19,18 @@ func main() {
 
 	e := echo.New()
 
+	// override AllowOrigins for CORS by setting an environment variable CORS_HOSTS.
+	// separate the URLs with ;
+	hosts, ok := os.LookupEnv("CORS_HOSTS");
+	hostsArr := []string{};
+	if ok {
+		hostsArr = strings.Split(hosts, ";")
+	} else {
+		hostsArr = []string{"*.middle-earth.house", "https://card-table.app"}
+	}
+
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins: []string{"*.middle-earth.house", "https://card-table.app"},
+		AllowOrigins: hostsArr,
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
 	}))
 	e.Use(middleware.Logger())


### PR DESCRIPTION
related to my issue https://github.com/erlloyd/cardtable/issues/124

this also needs CORS support, so now you can override the CORS origins via environment variables. If unset, it uses the same default URLs

use the environment variable CORS_HOSTS to override the CORS allowed hosts, separated by ;